### PR TITLE
Replace printf with fputs in hello.c

### DIFF
--- a/hello.c
+++ b/hello.c
@@ -2,7 +2,7 @@
 
 void print_message(const char *msg)
 {
-    printf("%s", msg);
+    fputs(msg, stdout);
 }
 
 int main(void)


### PR DESCRIPTION
Closes #1894

## Summary
The issue requested using puts() instead of printf(). However, puts() always appends a trailing newline, which would change the output from exactly 12 bytes (Hello world!) to 13 bytes, breaking the CI output contract.

## Solution
Used fputs("Hello world!", stdout) instead, which writes to stdout without appending a newline, preserving the exact 12-byte output and exit code 0. Compiles cleanly with -Wall -Wextra -Wpedantic -Werror.

## Why not puts()?
Per the C standard (C11 7.21.7.9): puts() always appends a newline character. There is no way to suppress this. fputs() is the closest alternative from the same function family.
